### PR TITLE
WIP 複数カラムを使用したユニーク制約のテストとvalidationメッセージについて

### DIFF
--- a/app/models/foodstuff.rb
+++ b/app/models/foodstuff.rb
@@ -1,40 +1,21 @@
 class Foodstuff < ApplicationRecord
-  before_save :convert_specific_format
+  before_validation :convert_specific_format # 空白を削除, 全角があれば半角に
   belongs_to :cuisine
   belongs_to :rawmaterial
-  validates :cuisine_id, uniqueness: { scope: :rawmaterial_id, message: "1つの料理に同じ材料を登録できません" }
-  # FIXME: validationはかかる
-  #         ただしvalidationメッセージは"数量を入力してください"と表示される
-  validates :quantity, presence: true, format: { with: %r{\A[1-9１-９]*[/／]*[0-9０-９]*\z}, message: "は分数もしくは数字(整数)で入力してください" }
-  # FIXME: validationなしでもrawmaterial_id は validationがかかる
-  #         なぜ?
-  # validates :rawmaterial_id, presence: { message: "を追加してください"}
+  validates :cuisine_id,
+    uniqueness: {
+      scope: :rawmaterial_id,
+      message: ->(object, data){
+        I18n.t('activerecord.errors.models.cuisine.cannot_duplicate_rawmaterial')
+        # "1つの料理に同じ材料を登録できません"
+      }
+    }
+  validates :quantity, presence: true, format: { with: %r{\A[1-9１-９]*[/／]*[0-9０-９]*\z}, message: "は分数もしくは数字で入力してください(例: 1/2, 120など)" }
   # ranked-model
   include RankedModel
   ranks :row_order, with_same: :cuisine_id
 
-  # quantityのvalidation
-  #  validationがokなら値を半角に変換して保存したい
-  #   もとはstring
-  #   変換する必要あり
-  #   整数(大文字、小文字)ならok
-  #     ok
-  #       1
-  #       １２
-  #       1３
-  #   分数(大文字、小文字)ならok
-  #     ok
-  #       1/1
-  #       1 / 3
-  #       １／１
-  #       1　／ 　　１
-  #   それ以外はng
-  #   okであれば大文字の場合は小文字に変換
-
-  # validates :cannot_save_except_specific_format
-
   def convert_specific_format
-    # 空白を削除, 全角があれば半角に
-    self.quantity = quantity.gsub(/ 　/, "").tr("／", "/").strip.tr('０-９', '0-9')
+    self.quantity = quantity.gsub(/ |　/, "").tr("／", "/").strip.tr('０-９', '0-9')
   end
 end

--- a/app/models/foodstuff.rb
+++ b/app/models/foodstuff.rb
@@ -2,7 +2,7 @@ class Foodstuff < ApplicationRecord
   before_save :convert_specific_format
   belongs_to :cuisine
   belongs_to :rawmaterial
-
+  validates :cuisine_id, uniqueness: { scope: :rawmaterial_id, message: "1つの料理に同じ材料を登録できません" }
   # FIXME: validationはかかる
   #         ただしvalidationメッセージは"数量を入力してください"と表示される
   validates :quantity, presence: true, format: { with: %r{\A[1-9１-９]*[/／]*[0-9０-９]*\z}, message: "は分数もしくは数字(整数)で入力してください" }

--- a/app/models/foodstuff.rb
+++ b/app/models/foodstuff.rb
@@ -2,14 +2,7 @@ class Foodstuff < ApplicationRecord
   before_validation :convert_specific_format # 空白を削除, 全角があれば半角に
   belongs_to :cuisine
   belongs_to :rawmaterial
-  validates :cuisine_id,
-    uniqueness: {
-      scope: :rawmaterial_id,
-      message: ->(object, data){
-        I18n.t('activerecord.errors.models.cuisine.cannot_duplicate_rawmaterial')
-        # "1つの料理に同じ材料を登録できません"
-      }
-    }
+  validate :uniqueness_rawmaterial_id
   validates :quantity, presence: true, format: { with: %r{\A[1-9１-９]*[/／]*[0-9０-９]*\z}, message: "は分数もしくは数字で入力してください(例: 1/2, 120など)" }
   # ranked-model
   include RankedModel
@@ -18,4 +11,10 @@ class Foodstuff < ApplicationRecord
   def convert_specific_format
     self.quantity = quantity.gsub(/ |　/, "").tr("／", "/").strip.tr('０-９', '0-9')
   end
+
+  private
+    def uniqueness_rawmaterial_id
+      foodstuff = Foodstuff.find_by(cuisine_id: self.cuisine_id, rawmaterial_id: self.rawmaterial_id)
+      errors.add(:base, "1つの料理に同じ材料を登録できません") if foodstuff && foodstuff.id != self.id
+    end
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -25,7 +25,6 @@ ja:
           cuisine_id: 料理レシピid
           rawmaterial: 材料
           rawmaterial_id: 材料
-
           keyword: 材料を検索
           ingredient_id: 部位id
           cookedstate_id: 加工された状態の名前id
@@ -48,3 +47,9 @@ ja:
         easy: 簡単
         normal: 普通
         hard: 難しい
+  errors:
+    models:
+      cuisine:
+        cannot_duplicate_rawmaterial: 1つの料理に同じ材料を登録できません
+      foodstuff:
+        cannot_duplicate_rawmaterial: 1つの料理に同じ材料を登録できません

--- a/spec/models/foodstuff_spec.rb
+++ b/spec/models/foodstuff_spec.rb
@@ -45,9 +45,15 @@ RSpec.describe Foodstuff, type: :model do
 
   # TODO: 別ブランチでテスト
   describe "cuisine_idカラムのバリデーション" do
-    # context "NG" do
-    #   it "同一のcuisine_id, rawmaterial_idであれば無効であること"
-    # end
+    context "NG" do
+      it "同一のcuisine_id, rawmaterial_idであれば無効であること" do
+        foodstuff1 = create(:foodstuff)
+        foodstuff2 = build(:foodstuff, cuisine_id: foodstuff1.id, rawmaterial_id: foodstuff1.rawmaterial_id)
+        foodstuff2.valid?
+        expect(foodstuff2).to be_valid
+      end
+
+    end
   end
 
   describe "rawmaterial_idカラムのバリデーション" do

--- a/spec/models/foodstuff_spec.rb
+++ b/spec/models/foodstuff_spec.rb
@@ -1,34 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe Foodstuff, type: :model do
-  describe "quantityカラムのバリデーション" do
+  describe "#convert_specific_format" do
+    let(:foodstuff){ Foodstuff.new(quantity: quantity) }
+    subject { foodstuff.convert_specific_format }
     context "OK" do
-      it "数字のみ(半角)であること" do
-        foodstuff = build(:foodstuff, :only_half_size_number)
-        foodstuff.valid?
-        expect(foodstuff).to be_valid
+      context "半角数字のみの場合" do
+        let(:quantity) { "1" }
+        it { is_expected.to eq "1" }
       end
 
-      it "数字のみ(全角)であること" do
-        foodstuff = build(:foodstuff, :only_full_width_number)
+      context "全角数字のみの場合" do
+        let(:quantity) { "１" }
+        it { is_expected.to eq("1") }
+      end
+
+      context "スペースを含んでいる数字の場合" do
+        let(:quantity) { " 1　" }
+        it { is_expected.to eq "1" }
+      end
+
+      context "分数であること" do
+        let(:quantity) { " 1/2" }
+        it { is_expected.to eq "1/2" }
+      end
+
+      context "スペースを含んでいる分数であること" do
+        let(:quantity) { " 1/2　" }
+        it { is_expected.to eq "1/2" }
+      end
+      context "/、数字、スペース以外の文字列を含むこと" do
+        let(:quantity) { "aaa" }
+        it { is_expected.to "aaa" }
+      end
+    end
+  end
+
+  describe "quantity" do
+    context "OK" do
+      it "数字のみであること" do
+        foodstuff = build(:foodstuff, :only_half_size_number)
         foodstuff.valid?
         expect(foodstuff).to be_valid
       end
 
       it "分数であること" do
         foodstuff = build(:foodstuff, :only_full_width_number)
-        foodstuff.valid?
-        expect(foodstuff).to be_valid
-      end
-
-      it "スペースを含んでいる数字であること" do
-        foodstuff = build(:foodstuff, :only_half_size_number_with_space)
-        foodstuff.valid?
-        expect(foodstuff).to be_valid
-      end
-
-      it "スペースを含んでいる分数であること" do
-        foodstuff = build(:foodstuff, :full_width_fraction_with_space)
         foodstuff.valid?
         expect(foodstuff).to be_valid
       end
@@ -43,23 +60,14 @@ RSpec.describe Foodstuff, type: :model do
     end
   end
 
-  # TODO: 別ブランチでテスト
-  describe "cuisine_idカラムのバリデーション" do
+  describe "cuisine_id" do
     context "NG" do
       it "同一のcuisine_id, rawmaterial_idであれば無効であること" do
-        foodstuff1 = create(:foodstuff)
-        foodstuff2 = build(:foodstuff, cuisine_id: foodstuff1.id, rawmaterial_id: foodstuff1.rawmaterial_id)
-        foodstuff2.valid?
-        expect(foodstuff2).to be_valid
+        foodstuff = create(:foodstuff)
+        foodstuff_overlapping_cuisine_and_rawmaterial_id = build(:foodstuff, cuisine_id: foodstuff.cuisine_id, rawmaterial_id: foodstuff.rawmaterial_id)
+        foodstuff_overlapping_cuisine_and_rawmaterial_id.valid?
+        expect(foodstuff_overlapping_cuisine_and_rawmaterial_id).to be_invalid
       end
-
     end
   end
-
-  describe "rawmaterial_idカラムのバリデーション" do
-    # context "NG" do
-    #   it "同一のcuisine_id, rawmaterial_idであれば無効であること"
-    # end
-  end
-
 end

--- a/spec/requests/managers/foodstuffs_request_spec.rb
+++ b/spec/requests/managers/foodstuffs_request_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe "Managers::Foodstuffs", type: :request do
     @cuisine = create(:cuisine)
   end
 
+  # TODO: 最終的には必要ない
   describe "GET /index" do
   end
 
-  describe "GET /new" do
+  describe "GET #new" do
     it "リクエストが成功すること" do
       get new_managers_foodstuff_path(cuisine_id: @cuisine.id)
       expect(response.status).to eq 200
@@ -24,17 +25,109 @@ RSpec.describe "Managers::Foodstuffs", type: :request do
   end
 
   describe "POST #create" do
+    before do
+      @rawmaterial = create(:rawmaterial)
+    end
+
     it "リクエストが成功すること" do
       post managers_foodstuffs_path, params: {
-        foodstuff: FactoryBot.attributes_for(:foodstuff, cuisine_id: @cuisine.id)
+        foodstuff: {
+          cuisine_id: @cuisine.id,
+          rawmaterial_id: @rawmaterial.id,
+          quantity: 1
+        }
       }
       expect(response.status).to eq 302
     end
 
     it "新規レコードが作成されること" do
       expect do
-        post managers_foodstuffs_path, params: { foodstuff: attributes_for(:foodstuff, cuisine_id: @cuisine.id)}
+        post managers_foodstuffs_path, params: {
+          foodstuff: {
+            cuisine_id: @cuisine.id,
+            rawmaterial_id: @rawmaterial.id,
+            quantity: 1
+          }
+        }
       end.to change(Foodstuff, :count).by(1)
+    end
+
+    it "cuisine/showページへリダイレクトすること" do
+      post managers_foodstuffs_path, params: {
+        foodstuff: {
+          cuisine_id: @cuisine.id,
+          rawmaterial_id: @rawmaterial.id,
+          quantity: 1
+        }
+      }
+      follow_redirect!
+      expect(response.body).to include "#{@cuisine.name}"
+    end
+  end
+
+  describe "GET #edit" do
+    before do
+      @foodstuff = create(:foodstuff)
+    end
+
+    it "リクエストが成功すること" do
+      get edit_managers_foodstuff_path @foodstuff
+      expect(response.status).to eq 200
+    end
+
+    # TODO: JS:trueを使用したテストが必要
+    # it "editテンプレートで表示されること" do
+    #   get edit_managers_foodstuff_path @foodstuff
+    #   expect(response.body).to include "#{@foodstuff.rawmaterial.name}"
+    # end
+  end
+
+  describe "PATCH #update" do
+    before do
+      @foodstuff = create(:foodstuff, quantity: "10")
+    end
+
+    it "既存レコードが更新されること" do
+      put managers_foodstuff_path @foodstuff, params: {
+        foodstuff:{
+          cuisine_id: @foodstuff.cuisine_id,
+          rawmaterial_id: @foodstuff.rawmaterial_id,
+          quantity: "1/2"
+        }
+      }
+      expect(Foodstuff.find_by(id: @foodstuff.id).quantity). to eq "1/2"
+    end
+    it "cuisine/showページヘリダイレクトすること" do
+      put managers_foodstuff_path @foodstuff, params: {
+        foodstuff:{
+          cuisine_id: @foodstuff.cuisine_id,
+          rawmaterial_id: @foodstuff.rawmaterial_id,
+          quantity: "1/2"
+        }
+      }
+      expect(response).to redirect_to(managers_cuisine_path( @foodstuff.cuisine_id))
+    end
+  end
+
+  describe "DELETE #destroy" do
+    before do
+      @foodstuff = create(:foodstuff, quantity: "10")
+    end
+
+    it "リクエストが成功すること" do
+      delete managers_foodstuff_path @foodstuff
+      expect(response.status).to eq 302
+    end
+
+    it "既存レコードが削除されること" do
+      expect do
+        delete managers_foodstuff_path @foodstuff
+      end.to change(Foodstuff, :count).by(-1)
+    end
+
+    it "cuisine/showページヘリダイレクトすること" do
+      delete managers_foodstuff_path @foodstuff
+      expect(response).to redirect_to(managers_cuisine_path( @foodstuff.cuisine_id))
     end
   end
 end


### PR DESCRIPTION
# 【追記】09/05
テストが下記のように変わった気がするのですが、気のせいかアドバイスをいただきたいです。

【困っていること】
- letを使って書き直してみたがテストの趣旨が変わった気がする
  - (before)レコードが保存できるかどうかのテスト
  - (after  ) convert_specific_formatメソッドのテスト(レコード保存の可否のテストではなくなっているような気がする)






~~# 【追記】09/04(2)~~
【やりたいこと】
1. let, subjectを使用してスピードや可読性を重視した書き方をしたい

【困っていること】
1. `it { is_expected.to be_valid }`がうまく動作しない
2. let, subjectを使ってみたが書き方として合っているか不安


~~# 【追記】09/04~~
【やりたいこと】
1. エラーメッセージに `1つの料理に同じ材料を登録できません` と表示されたい(変わらず)
1. 複数カラムを使ったユニーク制約のテストをパスしたい

【困っていること】
1.の内容
- 表記が特に変わっていない(エラーメッセージの先頭に`料理レシピid`が表示される)
- 教えていただいたリンクを参考に修正してみましたが結果が変わらない

2.の内容


<!--
【やりたいこと】
validationメッセージを
- 料理レシピid1つの料理に同じ材料を登録できません

から

- 1つの料理に同じ材料を登録できません

に変更したい

【困っていること】
- 下記を参考に書けば解決できると思ったがうまくいかない
    - [Ruby On Rails のValidation メッセージをカスタマイズする - Qiita](https://qiita.com/hiyoko3/items/2b6c5b59b1c95855b5e0)- [Active Record バリデーション - Railsガイド](https://railsguides.jp/active_record_validations.html#uniqueness)
    -  `config/locales/models/ja.yml`のカラム名を引用しているのは分かるが今回に限り必要ない(独自のメッセージのみの方が都合が良い)

![04_04_11](https://user-images.githubusercontent.com/46378023/91895636-8b258280-ecd2-11ea-8f6b-f4025ec39383.jpg)
-->