### PR TITLE
Feature/add genre and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ yarn-debug.log*
 
 new_user_credentials_app_for_job_change.csv
 .DS_Store
+db/afixtures/*
+db/fixtures/*

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'acts-as-taggable-on'
 gem 'bootstrap4-kaminari-views'
 gem 'carrierwave'
 gem 'counter_culture'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     after_commit_action (1.1.0)
@@ -382,6 +384,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on
   awesome_print
   better_errors
   binding_of_caller

--- a/app/controllers/managers/cuisines_controller.rb
+++ b/app/controllers/managers/cuisines_controller.rb
@@ -51,6 +51,6 @@ class Managers::CuisinesController < ApplicationController
   end
 
   def cuisine_params
-    params.require(:cuisine).permit(:name, :difficulty, :calories, :cooking_time, :description, :main_image)
+    params.require(:cuisine).permit(:name, :genre_id, :difficulty, :calories, :cooking_time, :description, :main_image, :tag_list)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,45 +1,14 @@
-// import 'core-js/stable'
-// import 'regenerator-runtime/runtime'
-
 import 'jquery/dist/jquery'
-// 原因1?
 import Rails from 'rails-ujs/lib/assets/compiled/rails-ujs'
-// import 'jquery-ui/ui/core'
-// import 'jquery-ui/ui/widgets/sortable'
-// import 'jquery-ui/sortable'
 import 'popper.js/dist/umd/popper.min'
 import 'bootstrap/dist/js/bootstrap'
 import 'clipboard/dist/clipboard.min'
 import '@fortawesome/fontawesome-free/js/all'
-// import Sortable from 'sortablejs/modular/sortable.complete.esm.js'
 
 Rails.start()
 window.$ = window.jQuery = require('jquery');
 require('data-confirm-modal')
 
-/* eslint no-console:0 */
-// This file is automatically compiled by Webpack, along with any other files
-// present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript and only use these pack files to reference
-// that code so it'll be compiled.
-//
-// To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
-// layout file, like app/views/layouts/application.html.erb
-
-
-// Uncomment to copy all static images under ../images to the output folder and reference
-// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
-// or the `imagePath` JavaScript helper below.
-//
-// const images = require.context('../images', true)
-// const imagePath = (name) => images(name, true)
-
-// console.log('Hello World from Webpacker')
-
-
-
-// import 'packs/managers/cuisines'
-// console.log($(window).width())
 
 $(function () {
   let xs = 0, sm = 576, md = 768, lg = 992, browserSize = 0, displaySizeText = ""

--- a/app/models/cuisine.rb
+++ b/app/models/cuisine.rb
@@ -1,6 +1,4 @@
 class Cuisine < ApplicationRecord
-  validates :name, presence: true, uniqueness: true
-  validates :description, presence: true
   enum difficulty: { easy: 0, normal: 1, hard: 2 }
   # has_many :rawmaterials
   # has_many :cookedstates
@@ -8,6 +6,11 @@ class Cuisine < ApplicationRecord
   has_many :foodstuffs, dependent: :destroy
   has_many :procedures, dependent: :destroy
   has_many :todaysmenus, dependent: :destroy
-  mount_uploader :main_image, ImageUploader
+  validates :description, presence: true
+  validates :genre_id, presence: { message: "を選択してください" }
+  validates :name, presence: true, uniqueness: true
   validates :main_image, presence: { message: "を追加してください" }
+
+  acts_as_taggable
+  mount_uploader :main_image, ImageUploader
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/views/managers/cuisines/_cuisine_form.html.erb
+++ b/app/views/managers/cuisines/_cuisine_form.html.erb
@@ -6,7 +6,11 @@
       <span>※</span><%= form.label :name %>
       <%= form.text_area :name, id: :cuisine_name, autofocus: true, class: 'form-control' %>
     </div>
-
+    <%# ジャンル %>
+    <div class="form-group">
+      <span>※</span><%= form.label :genre %><br />
+      <%= form.collection_select(:genre_id, Genre.all, :id, :name, {}, {selected: cuisine.genre_id, class: 'form-control'}) %>
+    </div>
     <%# お手軽度 %>
     <div class="form-group">
       <span>※</span><%= form.label :difficulty %>
@@ -17,6 +21,11 @@
     <div class="form-group">
       <span>※</span><%= form.label :cooking_time %>
       <%= form.text_field :cooking_time, id: :cuisine_cooking_time, autofocus: true, class: 'form-control' %>
+    </div>
+    <%# タグ %>
+    <div class="form-group">
+      <span>※</span><%= form.label :tag_list, "タグ" %>
+      <%= form.text_field :tag_list, value: @cuisine.tag_list.join(',') ,id: :cuisine_tag_list, autofocus: true, class: 'form-control' %>
     </div>
     <%# 説明 %>
     <div class="form-group">

--- a/app/views/managers/cuisines/show.html.erb
+++ b/app/views/managers/cuisines/show.html.erb
@@ -6,7 +6,11 @@
     <h1>料理レシピ概要</h1>
     <div class="cuisine-overview">
       <div class="col-sm-5">
+        <% if @cuisine.main_image.url.present? %>
         <%= image_tag @cuisine.main_image.url, class: 'img-fluid' %>
+        <% else %>
+          まだ登録がありません。
+        <% end %>
       </div>
       <div class="col-sm-7">
         <div class="title">
@@ -20,6 +24,14 @@
         </div>
         <div>
           レシピの説明:<%= @cuisine.description %>
+        </div>
+        <div>
+          タグ:
+          <% @cuisine.tag_list.each do |tag| %>
+            <span class="badge badge-light text-muted">
+              <%= tag %>
+            </span>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_user_navbar.html.erb
+++ b/app/views/shared/_user_navbar.html.erb
@@ -13,6 +13,8 @@
         <ul class="nav navbar-nav d-md-flex d-xl-flex ml-auto align-items-md-center align-items-xl-center">
           <%# TODO: Stock機能が完成したらのリンクを追加 %>
           <li class="nav-item d-xl-flex align-items-xl-center"><a class="nav-link  text-center" href="#">Stock</a></li>
+          <li class="nav-item d-xl-flex align-items-xl-center"><a class="nav-link  text-center" href="#">Purchase</a></li>
+          <li class="nav-item d-xl-flex align-items-xl-center"><a class="nav-link  text-center" href="#">History</a></li>
           <li class="nav-item d-xl-flex align-items-xl-center">
             <%= link_to 'Today', todaysmenus_path, class: "nav-link text-center" %>
           </li>

--- a/db/migrate/20201003054009_create_genres.rb
+++ b/db/migrate/20201003054009_create_genres.rb
@@ -1,0 +1,13 @@
+class CreateGenres < ActiveRecord::Migration[5.1]
+  def up
+    create_table :genres do |t|
+      t.string :name, null: false, unique: true
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :genres
+  end
+end

--- a/db/migrate/20201003064611_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064611_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20201003064612_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064612_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,30 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    # remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+      remove_foreign_key :taggings, :tags
+      remove_index ActsAsTaggableOn.taggings_table, :tag_id
+    end
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20201003064613_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064613_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20201003064614_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064614_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20201003064615_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064615_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20201003064616_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201003064616_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20201003072348_add_genre_id_to_cuisines.rb
+++ b/db/migrate/20201003072348_add_genre_id_to_cuisines.rb
@@ -1,0 +1,8 @@
+class AddGenreIdToCuisines < ActiveRecord::Migration[5.1]
+  def up
+    add_reference :cuisines, :genre, foreign_key: true, after: :name
+  end
+  def down
+    remove_reference :cuisines, :genre, foreign_key: true
+  end
+end

--- a/db/migrate/20201003105324_add_main_image_default_not_null_to_cuisines.rb
+++ b/db/migrate/20201003105324_add_main_image_default_not_null_to_cuisines.rb
@@ -1,0 +1,8 @@
+class AddMainImageDefaultNotNullToCuisines < ActiveRecord::Migration[5.1]
+  def up
+    change_column :cuisines, :main_image, :string, null: false
+  end
+  def down
+    change_column :cuisines, :main_image, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201003054009) do
+ActiveRecord::Schema.define(version: 20201003105324) do
 
   create_table "cookedstates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", comment: "加工された状態の名前"
@@ -34,13 +34,15 @@ ActiveRecord::Schema.define(version: 20201003054009) do
 
   create_table "cuisines", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false, comment: "料理名"
+    t.bigint "genre_id"
     t.integer "difficulty", limit: 1, default: 0, null: false, comment: "料理の難易度(enumで、低・中・高)"
     t.string "calories", comment: "摂取カロリー"
     t.integer "cooking_time", null: false, comment: "調理時間"
     t.string "description"
-    t.string "main_image", comment: "メイン画像"
+    t.string "main_image", null: false, comment: "メイン画像"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["genre_id"], name: "index_cuisines_on_genre_id"
     t.index ["name"], name: "index_cuisines_on_name", unique: true
   end
 
@@ -186,6 +188,33 @@ ActiveRecord::Schema.define(version: 20201003054009) do
     t.index ["user_id"], name: "index_stocks_on_user_id"
   end
 
+  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", collation: "utf8_bin"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "todaysmenus", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "cuisine_id"
     t.bigint "user_id"
@@ -232,6 +261,7 @@ ActiveRecord::Schema.define(version: 20201003054009) do
   end
 
   add_foreign_key "cookedstates", "foodcategories"
+  add_foreign_key "cuisines", "genres"
   add_foreign_key "favorites", "cuisines"
   add_foreign_key "favorites", "users"
   add_foreign_key "nutrients", "rawmaterials"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201002072909) do
+ActiveRecord::Schema.define(version: 20201003054009) do
 
   create_table "cookedstates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", comment: "加工された状態の名前"
@@ -69,6 +69,12 @@ ActiveRecord::Schema.define(version: 20201002072909) do
     t.datetime "updated_at", null: false
     t.index ["cuisine_id"], name: "index_foodstuffs_on_cuisine_id"
     t.index ["rawmaterial_id"], name: "index_foodstuffs_on_rawmaterial_id"
+  end
+
+  create_table "genres", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "ingredients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/tasks/seed_fu_gen.rake
+++ b/lib/tasks/seed_fu_gen.rake
@@ -31,7 +31,7 @@ namespace :seed_fu_gen do
     managers = Manager.all
     SeedFu::Writer.write("db/afixtures/#{t_folder_name}/01_manager.rb", class_name: 'Manager', seed_type: :seed_once) do |writer|
       managers.find_each do |mg|
-        writer << mg.attributes.except("created_at", "updated_at")
+        writer << mg.attributes.except("current_sign_in_at", "last_sign_in_at", "created_at", "updated_at")
       end
     end
 
@@ -39,7 +39,7 @@ namespace :seed_fu_gen do
     users = User.all
     SeedFu::Writer.write("db/afixtures/#{t_folder_name}/02_user.rb", class_name: "User", seed_type: :seed_once) do |writer|
     users.each do |user|
-        writer << user.attributes.except("created_at", "updated_at")
+        writer << user.attributes.except("current_sign_in_at", "last_sign_in_at", "created_at", "updated_at")
       end
     end
 
@@ -75,17 +75,25 @@ namespace :seed_fu_gen do
       end
     end
 
-    # 07_cookedstate.rb
-    cookedstates = Cookedstate.all
-    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/07_cookedstate.rb", class_name: "Cookedstate", seed_type: :seed_once) do |writer|
-      cookedstates.each do |cs|
-        writer << cs.attributes.except("created_at", "updated_at")
+    # # 08_tagging.rb
+    taggings = ActsAsTaggableOn::Tagging.all
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/08_tagging.rb", class_name: "Tagging", seed_type: :seed_once) do |writer|
+      taggings.each do |tgg|
+        writer << tgg.attributes.except("created_at", "updated_at")
       end
     end
 
-    # 08_cuisine.rb
+    # # 09_tag.rb
+    tags = ActsAsTaggableOn::Tag.all
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/09_tag.rb", class_name: "Tag", seed_type: :seed_once) do |writer|
+      tags.each do |tg|
+        writer << tg.attributes.except("created_at", "updated_at")
+      end
+    end
+
+    # 21_cuisine.rb
     cuisines = Cuisine.all
-    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/08_cuisine.rb", class_name: "Cuisine", seed_type: :seed_once) do |writer|
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/21_cuisine.rb", class_name: "Cuisine", seed_type: :seed_once) do |writer|
       cuisines.each do |cn|
         FileUtils.cp("#{Rails.root}/public#{cn.main_image}", "#{Rails.root}/db/afixtures/#{t_folder_name}#{cn.main_image}")
         cn.main_image = File.new("#{Rails.root}/public#{cn.main_image}")
@@ -93,23 +101,23 @@ namespace :seed_fu_gen do
       end
     end
 
-    # 10_foodstuff.rb
+    # 22_foodstuff.rb
     foodstuffs = Foodstuff.all
-    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/10_foodstuff.rb", class_name: "Foodstuff", seed_type: :seed_once) do |writer|
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/22_foodstuff.rb", class_name: "Foodstuff", seed_type: :seed_once) do |writer|
       foodstuffs.each do |fs|
         writer << fs.attributes.except("created_at", "updated_at")
       end
     end
 
-    # 11_procedure.rb
+    # 23_procedure.rb
     procedures = Procedure.all
-    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/11_procedure.rb", class_name: "Procedure", seed_type: :seed_once) do |writer|
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/23_procedure.rb", class_name: "Procedure", seed_type: :seed_once) do |writer|
       procedures.each do |pd|
         writer << pd.attributes.except("created_at", "updated_at")
       end
     end
 
-    # 12_stock.rb
+    # 24_stock.rb
     stocks = Stock.all
     SeedFu::Writer.write("db/afixtures/#{t_folder_name}/12_stock.rb", class_name: "Stock", seed_type: :seed_once) do |writer|
       stocks.each do |st|
@@ -144,7 +152,6 @@ namespace :seed_fu_all_datas do
       Dir.chdir("#{seed_gen_folder}/#{latest_folder_name}/uploads/#{ms}/")
       # target_folder内へ db/afixtures/#{latest_folder_name}/uploads/#{ms} フォルダの画像をコピーする
       Dir.glob('*') do |item|
-        puts item
         FileUtils.cp(item, "#{target_folder}")
       end
     end
@@ -158,5 +165,18 @@ namespace :seed_fu_all_datas do
     FileUtils.cp_r("#{Rails.root}/db/afixtures/#{latest_folder_name}/uploads", "#{Rails.root}/public/uploads")
     # "#{Rails.root}/db/afixtures/*"
 
+  end
+end
+
+namespace :change_main_image_properties do
+  desc 'change main_image properties'
+  task all: :environment do |t|
+    targetFile = Rails.root.join("db/fixtures/21_cuisine.rb")
+
+    buffer = File.open(targetFile, "r") { |f| f.read() }
+    File.open("#{targetFile}.bak" , "w") { |f| f.write(buffer) }
+    buffer.gsub!(/\"main_image\"=>\"/, "\"main_image\"=>Rails.root.join(\"db\/fixtures\/uploads\/cuisine\/")
+    buffer.gsub!(/\.jpg\"/, "\.jpg\")\.open")
+    File.open(targetFile, "w") { |f| f.write(buffer) }
   end
 end

--- a/lib/tasks/seed_fu_gen.rake
+++ b/lib/tasks/seed_fu_gen.rake
@@ -59,11 +59,11 @@ namespace :seed_fu_gen do
       end
     end
 
-    # 05_ingredient.rb
-    ingredients = Ingredient.all
-    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/05_ingredient.rb", class_name: "Ingredient", seed_type: :seed_once) do |writer|
-      ingredients.each do |ig|
-        writer << ig.attributes.except("created_at", "updated_at")
+    # 05_genre.rb
+    genres = Genre.all
+    SeedFu::Writer.write("db/afixtures/#{t_folder_name}/05_genre.rb", class_name: "Genre", seed_type: :seed_once) do |writer|
+      genres.each do |gr|
+        writer << gr.attributes.except("created_at", "updated_at")
       end
     end
 

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :genre do
+    sequence(:name) { |i| "ジャンル名#{i}"}
+  end
+end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Genre, type: :model do
+  it "名前があれば登録できること" do
+    genre = build(:genre)
+    genre.valid?
+    expect(genre).to be_valid
+  end
+
+  it "名前がなければ登録できないこと" do
+    genre = build(:genre, name: "")
+    genre.valid?
+    expect(genre).to be_invalid
+  end
+
+  it "名前が重複しないこと" do
+    genre = create(:genre, name: "ジャンル1")
+    another_genre = build(:genre, name: "ジャンル1")
+    expect(another_genre).to be_invalid
+  end
+end


### PR DESCRIPTION
【やりたいこと】
gem act-as-taggles-onで作成されたテーブル(taggings, tags)のDBの値を、
- Tagging.all, Tag.allでDBのデータを取得できる
- DBのseedファイルとして抽出、作成できる
ようにしたい。

【困っていること】
gem act-as-taggles-onによる実装のため、Tagging.all, Tag.allでDBのデータを取得できない。
リンク([ruby on rails - How to db:seed my acts-as-taggable-on tags? - Stack Overflow](https://stackoverflow.com/questions/6413681/how-to-dbseed-my-acts-as-taggable-on-tags))ではDBから取得せず自分で取り出しているし、調べていてもそれらしき記事がない。
seedした後に自分で追加するしかないのか?

## 参考サイト
- [Railsでacts-as-taggable-onを使ってタグ管理を行う - Rails Webook](http://web.archive.org/web/20190501235841/https://ruby-rails.hatenadiary.com/entry/20150225/1424858414)
- [Rails | acts-as-taggable-on を使ったタグ機能の実装 | 備忘録 - Qiita](https://qiita.com/ddd555/items/e1caa8b73d118822a0a2)
- [RailsにBootstrap Tags InputのJQueryを導入する | 目指せ、スーパーエンジニア](https://hirocorpblog.com/post-160/)
- [Importing Bootstrap 4 tags input with webpack and rails - Stack Overflow](https://stackoverflow.com/questions/60494094/importing-bootstrap-4-tags-input-with-webpack-and-rails)