### PR TITLE
Feature/run in production mode on local machine

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -60,5 +60,5 @@ production:
 production:
   <<: *default
   database: webapp_production
-  username: webapp
-  password: <%= ENV['WEBAPP_DATABASE_PASSWORD'] %>
+  # username: webapp
+  # password: <%= ENV['WEBAPP_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -4,6 +4,8 @@ upstream webapp {
 
 server {
   listen 80;
+  # FIXME: productionもlocalhostも変わらない?
+  # server_name localhost;
   server_name 54.168.231.127;
 
   access_log /var/log/nginx/access.log;
@@ -14,6 +16,7 @@ server {
   client_max_body_size 100m;
   error_page 404             /404.html;
   error_page 505 502 503 504 /500.html;
+  # 静的ファイルが見つかればそれを返却。なければwebappへ接続
   try_files  $uri/index.html $uri @webapp;
   keepalive_timeout 5;
 

--- a/db/migrate/20200522054357_create_ingredients.rb
+++ b/db/migrate/20200522054357_create_ingredients.rb
@@ -1,3 +1,4 @@
+class CreateIngredients < ActiveRecord::Migration[5.1]
   def change
     create_table :ingredients do |t|
       t.string :name, null: false, comment: "部位の名称"
@@ -6,3 +7,4 @@
       t.timestamps
     end
   end
+end

--- a/db/migrate/20200522201535_create_cuisines.rb
+++ b/db/migrate/20200522201535_create_cuisines.rb
@@ -4,7 +4,6 @@ class CreateCuisines < ActiveRecord::Migration[5.1]
       t.string :name, null: false, comment: "料理名"
       t.string :calories, null: false, comment: "摂取カロリー"
       t.integer :cooking_time, null: false, comment: "調理時間"
-      t.integer :cooking_time, null: false, comment: "お手軽度, (enumで、低、中・高)"
       t.string :main_image, null: false, comment: "メイン画像"
       t.timestamps
     end

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -3,30 +3,47 @@
 version: '3.7'
 
 services:
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: root
+    ports:
+        - "4306:3306"
+    volumes:
+        - db-data:/var/lib/mysql
+
   web:
     build:
       context: .
       dockerfile: ./Dockerfile.production
     command: bundle exec puma -C config/puma.rb -e production
+    environment:
+      RAILS_ENV: production
+      # [【Rails】assets:precompileは成功しているのにpumaを起動してもimageもjsもcssもNotFound（RAILS_SERVE_STATIC_FILESの話） - Qiita](https://qiita.com/at-946/items/b7d467bf25c40fcfca44)
+      # [Rails に静的ファイルの配信をお願いする - Qiita](https://qiita.com/gouf/items/01d608d3ec46ba65f3c2)
+      RAILS_SERVE_STATIC_FILES: 'true'
     volumes:
       - .:/webapp
-      - public-data:/webapp/public
-      - tmp-data:/webapp/tmp
-      - log-data:/webapp/log
+      # - public-data:/webapp/public
+      # - tmp-data:/webapp/tmp
+      # - log-data:/webapp/log
       - bundle:/usr/local/bundle
       - node-modules:/webapp/node_modules
     # 公開ポートの設定(ホスト(Mac側):コンテナ側)
-    # ports:
-    #   - "3000:3000"
-    #   - "3035:3035"
+    ports:
+      - "3000:3000"
+      - "3035:3035"
+    links:
+      - db
 
   nginx:
     build:
       context: .
       dockerfile: ./containers/nginx/Dockerfile
-    volumes:
-      - public-data:/webapp/public
-      - tmp-data:/webapp/tmp
+    # volumes:
+    #   - public-data:/webapp/public
+    #   - tmp-data:/webapp/tmp
     ports:
       - 80:80
     depends_on:
@@ -34,7 +51,11 @@ services:
 
 volumes:
   bundle:
+    driver: local
+  db-data:
+    driver: local
   node-modules:
-  public-data:
-  tmp-data:
-  log-data:
+    driver: local
+#   public-data:
+#   tmp-data:
+#   log-data:


### PR DESCRIPTION
【困っていること】
Mac上でproductionモードでDocker+Rails+MySQL+nginxの構成で上手く動作するか試していますが、
BootStrap関連のcss,jsが読み込まれずに画面構成が崩れる(localhost, localhost:3000で表示される画面構成は同じ)状態で困っています。

![difference_looking](https://user-images.githubusercontent.com/46378023/111605490-b0668200-8819-11eb-9005-bcd222ffea9f.jpg)


【現状】
- Mac上でdevelopmentモードで動作することは確認できている
- Mac上でproductionモードで動作することは確認できている
    - アプリを起動するまでにやったことは、DBの作成、マイグレーション、初期データの投入、assets:precompileです。
    - アプリは`docker-compose -f docker-compose.production.yml up`コマンドで起動しました。
- ただしBootStrap関連のcss,jsが読み込まれずに画面構成が崩れる(localhost, localhost:3000で表示される画面構成は同じ)
- `docker-compose -f docker-compose.production.yml up`を実行して`localhost`にアクセスすると下記のログがterminalに表示される(念のためログを全て載せます)
```bash
docker-compose -f docker-compose.production.yml up
WARNING: Found orphan containers (app_for_job_change_chrome_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Starting app_for_job_change_db_1 ... done
Starting app_for_job_change_web_1 ... done
Starting app_for_job_change_nginx_1 ... done
Attaching to app_for_job_change_db_1, app_for_job_change_web_1, app_for_job_change_nginx_1
db_1     | 2021-03-18 06:41:45+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.31-1debian10 started.
db_1     | 2021-03-18 06:41:45+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
db_1     | 2021-03-18 06:41:45+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.31-1debian10 started.
db_1     | 2021-03-18T06:41:45.619134Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
db_1     | 2021-03-18T06:41:45.620363Z 0 [Note] mysqld (mysqld 5.7.31) starting as process 1 ...
db_1     | 2021-03-18T06:41:45.623524Z 0 [Note] InnoDB: PUNCH HOLE support available
db_1     | 2021-03-18T06:41:45.623572Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
db_1     | 2021-03-18T06:41:45.623583Z 0 [Note] InnoDB: Uses event mutexes
db_1     | 2021-03-18T06:41:45.623592Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
db_1     | 2021-03-18T06:41:45.623603Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
db_1     | 2021-03-18T06:41:45.623638Z 0 [Note] InnoDB: Using Linux native AIO
db_1     | 2021-03-18T06:41:45.623864Z 0 [Note] InnoDB: Number of pools: 1
db_1     | 2021-03-18T06:41:45.623958Z 0 [Note] InnoDB: Using CPU crc32 instructions
db_1     | 2021-03-18T06:41:45.625625Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
db_1     | 2021-03-18T06:41:45.638493Z 0 [Note] InnoDB: Completed initialization of buffer pool
db_1     | 2021-03-18T06:41:45.641844Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
db_1     | 2021-03-18T06:41:45.652187Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
db_1     | 2021-03-18T06:41:45.675876Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
db_1     | 2021-03-18T06:41:45.676439Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
db_1     | 2021-03-18T06:41:45.706143Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
db_1     | 2021-03-18T06:41:45.708469Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
db_1     | 2021-03-18T06:41:45.709366Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
db_1     | 2021-03-18T06:41:45.712515Z 0 [Note] InnoDB: Waiting for purge to start
db_1     | 2021-03-18T06:41:45.763548Z 0 [Note] InnoDB: 5.7.31 started; log sequence number 42039750
db_1     | 2021-03-18T06:41:45.764144Z 0 [Note] Plugin 'FEDERATED' is disabled.
db_1     | 2021-03-18T06:41:45.774188Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
db_1     | 2021-03-18T06:41:45.780262Z 0 [Note] InnoDB: Buffer pool(s) load completed at 210318  6:41:45
db_1     | 2021-03-18T06:41:45.781796Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
db_1     | 2021-03-18T06:41:45.781819Z 0 [Note] Skipping generation of SSL certificates as certificate files are present in data directory.
db_1     | 2021-03-18T06:41:45.782452Z 0 [Warning] CA certificate ca.pem is self signed.
db_1     | 2021-03-18T06:41:45.782486Z 0 [Note] Skipping generation of RSA key pair as key files are present in data directory.
db_1     | 2021-03-18T06:41:45.782949Z 0 [Note] Server hostname (bind-address): '*'; port: 3306
db_1     | 2021-03-18T06:41:45.783676Z 0 [Note] IPv6 is available.
db_1     | 2021-03-18T06:41:45.783763Z 0 [Note]   - '::' resolves to '::';
db_1     | 2021-03-18T06:41:45.783798Z 0 [Note] Server socket created on IP: '::'.
db_1     | 2021-03-18T06:41:45.786434Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
db_1     | 2021-03-18T06:41:45.803317Z 0 [Note] Event Scheduler: Loaded 0 events
db_1     | 2021-03-18T06:41:45.804302Z 0 [Note] mysqld: ready for connections.
db_1     | Version: '5.7.31'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
web_1    | Puma starting in single mode...
web_1    | * Puma version: 5.2.1 (ruby 2.7.2-p137) ("Fettisdagsbulle")
web_1    | *  Min threads: 5
web_1    | *  Max threads: 5
web_1    | *  Environment: production
web_1    | *          PID: 1
web_1    | * Listening on http://0.0.0.0:3000
web_1    | * Listening on unix:///webapp/tmp/sockets/puma.sock
web_1    | Use Ctrl-C to stop
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET / HTTP/1.1" 200 5900 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET /assets/application-6955b7d43c36c2e00f585f376eb868a56c028efea567e0d9a8f06d2e781d3a16.css HTTP/1.1" 304 0 "http://localhost/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET /packs/js/application-e2fa607a36268bd325e5.js HTTP/1.1" 304 0 "http://localhost/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET /assets/bootstrap/dist/css/bootstrap.css HTTP/1.1" 404 1722 "http://localhost/assets/application-6955b7d43c36c2e00f585f376eb868a56c028efea567e0d9a8f06d2e781d3a16.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET /assets/jquery-ui/themes/base/sortable.css HTTP/1.1" 404 1722 "http://localhost/assets/application-6955b7d43c36c2e00f585f376eb868a56c028efea567e0d9a8f06d2e781d3a16.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
nginx_1  | 172.18.0.1 - - [18/Mar/2021:06:43:26 +0000] "GET /assets/about_top_image-dbc60267dc6631bdbd2957c8b68553960c82134e2614cb84d63725077c988155.jpg HTTP/1.1" 304 0 "http://localhost/assets/application-6955b7d43c36c2e00f585f376eb868a56c028efea567e0d9a8f06d2e781d3a16.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4442.4 Safari/537.36"
```

【補足】
local端末でproductionモードで動作させるためにDBの作成、マイグレーションを実行していると齟齬が発生していたため修正した内容もcommitに含まれています。

