### PR TITLE
検索結果でエラーが発生する問題を修正

### DIFF
--- a/app/helpers/keywords_helper.rb
+++ b/app/helpers/keywords_helper.rb
@@ -15,7 +15,7 @@ module KeywordsHelper
       "10分以下"
     when "lt_minutes20"
       "20分以下"
-    when "gt_minutes"
+    when "gt_minutes21"
       "20分以上"
     when "not-enum-ranking"
       "お気に入り"


### PR DESCRIPTION
トップページで21分以上のタグをクリックすると以下のエラーが発生するのでそれを修正する
![07_08_03](https://user-images.githubusercontent.com/46378023/138573066-476b0e7a-3cac-4cbd-97e1-6a9f3fda558c.jpg)
る
