### PR TITLE
fix: 指定したキーが存在しない時トップページにリダイレクトするように変更

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -9,6 +9,8 @@ class KeywordsController < ApplicationController
       @cuisines = Cuisine.where(cooking_time: @enum_key).includes(:user).page(params[:page]).per(KAMINARI_PAGINATION_COUNT)
     when "not-enum-ranking"
       @cuisines = Cuisine.includes(:user).where('favorites_count > ?', 0).order(favorites_count: :desc).page(params[:page]).per(KAMINARI_PAGINATION_COUNT)
+    else
+      redirect_to root_path, flash: { alert: "検索された値はありませんでした" }
     end
   end
 end


### PR DESCRIPTION
トップページから上部のキーワードのボタンを押下した時に`enum_key`に予想外の値が代入されている時に以下のエラーが発生する。
![07_48_07](https://user-images.githubusercontent.com/46378023/138573785-5ee8f076-6a5e-4d7b-a8f5-4f902c4a3a5c.jpg)

caseのelseを使用してトップページにリダイレクトさせる