### PR TITLE
デプロイ先をAWSからHerokuに移行する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ ENTRYPOINT [ "entrypoint.sh" ]
 EXPOSE 3000
 
 EXPOSE 3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["rails", "server", "-b", "0.0.0.0", "-p", "${PORT:-3000}"]

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'acts-as-taggable-on', '~> 8.0' # for not failing migration
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap4-kaminari-views'
 gem 'carrierwave'
+gem 'cloudinary'
 gem 'counter_culture'
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     anbt-sql-formatter (0.1.0)
     ast (2.4.2)
     awesome_print (1.9.2)
+    aws_cf_signer (0.1.3)
     backport (1.2.0)
     bcrypt (3.1.16)
     benchmark (0.2.0)
@@ -103,6 +104,9 @@ GEM
       ssrf_filter (~> 1.0)
     childprocess (4.1.0)
     choice (0.2.0)
+    cloudinary (1.21.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     counter_culture (3.0.0)
@@ -125,6 +129,8 @@ GEM
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
     docile (1.4.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -171,6 +177,9 @@ GEM
     globalid (0.5.2)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -226,6 +235,7 @@ GEM
     msgpack (1.4.2)
     multi_json (1.15.0)
     mysql2 (0.5.3)
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -305,6 +315,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -417,6 +432,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
     uniform_notifier (1.14.2)
     vcr (6.0.0)
@@ -462,6 +480,7 @@ DEPENDENCIES
   byebug
   capybara
   carrierwave
+  cloudinary
   counter_culture
   devise
   devise-i18n

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,10 +1,13 @@
-class ImageUploader < CarrierWave::Uploader::Base
-  include CarrierWave::MiniMagick
+# frozen_string_literal: true
 
-  # Choose what kind of storage to use for this uploader:
+class ImageUploader < CarrierWave::Uploader::Base
   if Rails.env.production?
-    storage :fog
+    include Cloudinary::CarrierWave
+    CarrierWave.configure do |config|
+      config.cache_storage = :file
+    end
   else
+    include CarrierWave::MiniMagick
     storage :file
   end
 
@@ -12,30 +15,12 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}"
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
   def size_range
     1..10.megabytes
   end
 
-  # Process files as they are uploaded:
   process convert: 'jpg'
   process resize_to_fit: [400, 400]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
 
   def extension_allowlist
     %w[jpg jpeg gif png]

--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -1,10 +1,13 @@
-class ProfileImageUploader < CarrierWave::Uploader::Base
-  include CarrierWave::MiniMagick
+# frozen_string_literal: true
 
-  # Choose what kind of storage to use for this uploader:
+class ProfileImageUploader < CarrierWave::Uploader::Base
   if Rails.env.production?
-    storage :fog
+    include Cloudinary::CarrierWave
+    CarrierWave.configure do |config|
+      config.cache_storage = :file
+    end
   else
+    include CarrierWave::MiniMagick
     storage :file
   end
 

--- a/config/cloudinaly.yml
+++ b/config/cloudinaly.yml
@@ -1,0 +1,18 @@
+development:
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+  enhance_image_tag: true
+  static_file_support: false
+production:
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+  enhance_image_tag: true
+  static_file_support: true
+test:
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+  enhance_image_tag: true
+  static_file_support: false

--- a/config/database.yml
+++ b/config/database.yml
@@ -32,12 +32,11 @@ test:
 production:
   <<: *default
   database: <%= ENV['DB_DATABASE'] %>
-  charset: utf8mb4
-  collation: utf8mb4_general_ci
   encoding: utf8mb4
   host: <%= ENV['DB_HOST_ENDPOINT'] %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
+  url: <%= ENV['JAWSDB_URL'] %>
 
 # production:
 #   <<: *default


### PR DESCRIPTION
### 概要
以下のことを踏まえてデプロイ先をAWSからHerokuに移行する
- AWSの無料枠の終了が迫っていること
- アプリは動作するようにしておきたい

### 移行先の環境
- Heroku(データはawsのmysqlからインポートする)
- Cloudinary

※ nginxは使用しない方向

### 参考リンク
#### 全体像
以下のリンクがわかりやすいので参考にする
[【Rails + MySQL】AWS→herokuの移行 – blog.aiandrox](https://blog.aiandrox.com/posts/tech/2021/02/10/)

#### Rails x CarrierWave x Cloudinary
公式
[CarrierWave integration | Cloudinary](https://cloudinary.com/documentation/rails_carrierwave)
[cloudinary/cloudinary_gem: Cloudinary GEM for Ruby on Rails integration](https://github.com/cloudinary/cloudinary_gem)

ただ上記では細かいカスタム方法しかわからないので全体像は以下を参考に変更
[Cloudinary + Rails 画像アップロード - Qiita](https://qiita.com/ttexan/items/a1004121e806c477d030)
[RailsでCloudinaryを使う - ノンカフェインであなたにやさしい](https://akinov.hatenablog.com/entry/2018/08/19/182258)